### PR TITLE
Update Dockerfile to correct deluge-client.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN \
 	echo "**** install plugin: misc ****" && \
 	pip install --upgrade \
 		transmissionrpc \
-		deluge_client \
+		deluge-client \
 		irc_bot && \
 	echo "**** install plugins: rar ****" && \
 	apk add --no-cache unrar && \


### PR DESCRIPTION
Python module docker-client has a hyphen instead of an underscore.